### PR TITLE
Fix small error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ please try below by following the [getting started](http://mesos.apache.org/gett
     $ vagrant ssh
     vagrant@mesos$ cd mesos/build
     vagrant@mesos$ src/test-framework --master=mesos:5050       # or --master=zk://mesos:2181/mesos
-    vagrant@mesos$ src/example/java/test-framework mesos:5050   # or zk://mesos:2181/mesos
-    vagrant@mesos$ src/example/python/test-framework mesos:5050 # or zk://mesos:2181/mesos
+    vagrant@mesos$ src/examples/java/test-framework mesos:5050   # or zk://mesos:2181/mesos
+    vagrant@mesos$ src/examples/python/test-framework mesos:5050 # or zk://mesos:2181/mesos
 
 Multinode environment
 ----


### PR DESCRIPTION
The paths to the test from the Mesos getting started guide were just slightly incorrect. Fixed them so that users can copy the commands directly from the README without any errors.
