### PR TITLE
Fix the "uninitialized constant YAML" error on running vagrant commands

### DIFF
--- a/multinodes/Vagrantfile
+++ b/multinodes/Vagrantfile
@@ -1,5 +1,6 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+require 'yaml'
 require './lib/gen_node_infos'
 
 base_dir = File.expand_path(File.dirname(__FILE__))


### PR DESCRIPTION
Hi,

Thanks for sharing this!

I have noticed that I get the error "uninitialized constant YAML" on running vagrant commands using multinodes' Vagrantfile.
I have encountered the error on at least Vagrant 1.2.2 and 1.3.5.

```
$ vagrant plugin install vagrant-omnibus
Vagrant failed to initialize at a very early stage:

There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /Users/yusuke.kuoka/vagrant/vagrant-mesos/multinodes/Vagrantfile
Message: uninitialized constant YAML
```

It is fixed when I add `require 'yaml'` on top of the Vagrantfile.
I'm sending this PR to do so.
Please merge this if you have the same issue.

Thanks,
Yusuke
