### PR TITLE
Add support for custom AMI's if a non-default is needed

### DIFF
--- a/multinodes/Vagrantfile
+++ b/multinodes/Vagrantfile
@@ -59,6 +59,9 @@ Vagrant.configure("2") do |config|
 
         aws.region = conf["region"]
         aws.ami = ami[conf["region"]]
+        if conf["custom_ami"] then
+            aws.ami = conf["custom_ami"]
+        end
         aws.instance_type = ninfo[:instance_type]
         aws.keypair_name = conf["keypair_name"]
         aws.subnet_id = conf["subnet_id"]
@@ -216,6 +219,9 @@ SCRIPT
 
         aws.region = conf["region"]
         aws.ami = ami[conf["region"]]
+        if conf["custom_ami"] then
+            aws.ami = conf["custom_ami"]
+        end
         aws.instance_type = conf["marathon_instance_type"]
         aws.keypair_name = conf["keypair_name"]
         aws.subnet_id = conf["subnet_id"]

--- a/multinodes/cluster.yml
+++ b/multinodes/cluster.yml
@@ -48,6 +48,8 @@ security_groups: ["EDIT_HERE"]     # array of VPN security groups. e.g. ['sg*** 
 keypair_name: EDIT_HERE
 ssh_private_key_path: EDIT_HERE
 region: EDIT_HERE
+# set a custom AMI to use if you need something other than the defaults
+#custom_ami: EDIT_HERE
 
 # see http://aws.amazon.com/ec2/instance-types/#selecting-instance-types
 zk_instance_type: m1.small

--- a/standalone/Vagrantfile
+++ b/standalone/Vagrantfile
@@ -59,6 +59,9 @@ Vagrant.configure("2") do |config|
 
     aws.region = conf["region"]
     aws.ami = ami[conf["region"]]
+    if conf["custom_ami"] then
+      aws.ami = conf["custom_ami"]
+    end
     aws.instance_type = conf["instance_type"]
     aws.keypair_name = conf["keypair_name"]
     aws.security_groups = conf["security_groups"]

--- a/standalone/aws_config.yaml
+++ b/standalone/aws_config.yaml
@@ -6,6 +6,8 @@ secret_access_key: EDIT_HERE
 # ["ap-northeast-1", "ap-southeast-1", "eu-west-1", "sa-east-1", "us-east-1",
 #  "us-west-1", "ap-southeast-2", "us-west-2"]
 region: us-east-1
+# set a custom AMI to use if you need something other than the defaults
+#custom_ami: EDIT_HERE
 
 # array of security groups. e.g. ['sg*** ']
 # please make sure to open ports 22(SSH), 5050(Mesos), 8080(Marathon)


### PR DESCRIPTION
The AMI should be configurable -- for example if i want to use t2.medium i need an hvm AMI which would mean  editing aws_region_ami.yaml rather than just the cluster.yml
