### PR TITLE
support .dockercfg file.

### DIFF
--- a/multinodes/Vagrantfile
+++ b/multinodes/Vagrantfile
@@ -167,6 +167,16 @@ SCRIPT
           sudo restart zookeeper
 SCRIPT
       end
+
+      # If you wanted use `.dockercfg` file
+      # Please place the file simply on this directory
+      if File.exist?(".dockercfg")
+        config.vm.provision :shell, :priviledged => true, :inline <<SCRIPT
+          cp /vagrant/.dockercfg /root/.dockercfg
+          chmod 600 /root/.dockercfg
+          chown root /root/.dockercfg
+        SCRIPT
+      end
     end
   end
 
@@ -244,6 +254,15 @@ SCRIPT
 SCRIPT
       end
 
+      # If you wanted use `.dockercfg` file
+      # Please place the file simply on this directory
+      if File.exist?(".dockercfg")
+        config.vm.provision :shell, :priviledged => true, :inline <<SCRIPT
+          cp /vagrant/.dockercfg /root/.dockercfg
+          chmod 600 /root/.dockercfg
+          chown root /root/.dockercfg
+        SCRIPT
+      end
     end
   end
 end

--- a/standalone/Vagrantfile
+++ b/standalone/Vagrantfile
@@ -117,4 +117,13 @@ Vagrant.configure("2") do |config|
     nohup /opt/chronos/bin/start-chronos.bash --master zk://localhost:2181/mesos --zk_hosts zk://localhost:2181/mesos --http_port 8081 > /var/log/chronos/nohup.log 2> /var/log/chronos/nohup.log < /dev/null &
 SCRIPT
 
+  # If you wanted use `.dockercfg` file
+  # Please place the file simply on this directory
+  if File.exist?(".dockercfg")
+    config.vm.provision :shell, :priviledged => true, :inline <<SCRIPT
+      cp /vagrant/.dockercfg /root/.dockercfg
+      chmod 600 /root/.dockercfg
+      chown root /root/.dockercfg
+    SCRIPT
+  end
 end


### PR DESCRIPTION
 This will just copy `.dockercfg` file which user placed in the directory which contains `Vagrantfile` to `/root/.dockercfg` in all vm instances.

ref #27 
